### PR TITLE
Optimizing expiration complexity

### DIFF
--- a/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
+++ b/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 
 @Slf4j
@@ -19,8 +19,15 @@ public class CacheRepository {
     private final Map<LocalDateTime, Map<String, CacheEntry>> expirationMap = new ConcurrentHashMap<>();
 
     public Optional<String> getOptionalValueByKey(String key) {
-        return Optional.ofNullable(cacheMap.get(key))
-                .map(CacheEntry::getValue);
+        CacheEntry cacheEntry = cacheMap.get(key);
+
+        if (nonNull(cacheEntry) && nonNull(cacheEntry.getExpiresAt())
+                && LocalDateTime.now().isAfter(cacheEntry.getExpiresAt())) {
+            cacheMap.remove(key, cacheEntry);
+            cacheEntry = null;
+        }
+
+        return Optional.ofNullable(cacheEntry).map(CacheEntry::getValue);
     }
 
     public void save(CacheEntry cacheEntry) {

--- a/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
+++ b/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
@@ -4,19 +4,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Objects.nonNull;
-import static java.util.Optional.ofNullable;
 
 @Slf4j
 @Component
 public class CacheRepository {
     private final Map<String, CacheEntry> cacheMap = new ConcurrentHashMap<>();
-    private final Map<LocalDateTime, Map<String, CacheEntry>> expirationMap = new ConcurrentHashMap<>();
 
     public Optional<String> getOptionalValueByKey(String key) {
         CacheEntry cacheEntry = cacheMap.get(key);
@@ -33,15 +30,6 @@ public class CacheRepository {
     public void save(CacheEntry cacheEntry) {
         log.debug("Key {} added to cache with tll {}.", cacheEntry.getKey(), cacheEntry.getTtl());
         cacheMap.put(cacheEntry.getKey(), cacheEntry);
-        if (!isNull(cacheEntry.getExpiresAt())) {
-            saveExpirationEntry(cacheEntry);
-        }
-    }
-
-    private void saveExpirationEntry(CacheEntry cacheEntry) {
-        Map<String, CacheEntry> expirationEntry = getExpirationEntry(cacheEntry);
-        expirationEntry.put(cacheEntry.getKey(), cacheEntry);
-        log.debug("Key {} added to expiration map with tll {}.", cacheEntry.getKey(), cacheEntry.getTtl());
     }
 
     public void deleteByKey(String key) {
@@ -51,22 +39,10 @@ public class CacheRepository {
     }
 
     public void deleteByExpirationTime(LocalDateTime time) {
-        expirationMap.keySet()
+        cacheMap.values()
                 .stream()
-                .filter(time::isAfter)
-                .map(expirationMap::remove)
-                .map(Map::values)
-                .flatMap(Collection::stream)
+                .filter(cacheEntry -> nonNull(cacheEntry.getExpiresAt()) && cacheEntry.getExpiresAt().isBefore(time))
                 .forEach(cacheEntry -> cacheMap.remove(cacheEntry.getKey(), cacheEntry));
-    }
-
-    private Map<String, CacheEntry> getExpirationEntry(CacheEntry cacheEntry) {
-        Map<String, CacheEntry> expirationEntry = expirationMap.get(cacheEntry.getExpiresAt());
-        if (isNull(expirationEntry)) {
-            expirationEntry = new ConcurrentHashMap<>();
-            expirationMap.put(cacheEntry.getExpiresAt(), expirationEntry);
-        }
-        return expirationEntry;
     }
 
 }

--- a/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
+++ b/src/main/java/com/tmg/codingchallenge/data/CacheRepository.java
@@ -38,9 +38,9 @@ public class CacheRepository {
     }
 
     public void deleteByKey(String key) {
-        final CacheEntry cacheEntryFound = cacheMap.remove(key);
-        removeExpirationEntry(cacheEntryFound);
-        log.debug("Key {} removed from cache.", key);
+        if (nonNull(cacheMap.remove(key))) {
+            log.debug("Key {} removed from cache.", key);
+        }
     }
 
     public void deleteByExpirationTime(LocalDateTime time) {
@@ -60,17 +60,6 @@ public class CacheRepository {
             expirationMap.put(cacheEntry.getExpiresAt(), expirationEntry);
         }
         return expirationEntry;
-    }
-
-    private void removeExpirationEntry(CacheEntry cacheEntry) {
-        ofNullable(cacheEntry)
-                .map(CacheEntry::getExpiresAt)
-                .map(expirationMap::get)
-                .ifPresent(expirationEntry -> {
-                    expirationEntry.remove(cacheEntry.getKey());
-                    if (expirationEntry.isEmpty())
-                        expirationMap.remove(cacheEntry.getExpiresAt());
-                });
     }
 
 }

--- a/src/main/java/com/tmg/codingchallenge/presentation/job/CacheExpirationJob.java
+++ b/src/main/java/com/tmg/codingchallenge/presentation/job/CacheExpirationJob.java
@@ -14,9 +14,9 @@ public class CacheExpirationJob {
     private final CacheExpirationService service;
 
     /**
-     * Cron expression "* * * * * *" = Runs every second.
+     * Cron expression "0 0/30 * * * ?" = Runs at minutes 0 and 30 from each hour.
      */
-    @Scheduled(cron = "* * * * * *")
+    @Scheduled(cron = "0 0/30 * * * ?")
     public void removeExpiredCacheEntries() {
         log.debug("Executing Cache Expiring Job");
         service.clearExpiredCacheEntries();

--- a/src/main/java/com/tmg/codingchallenge/presentation/service/CacheExpirationServiceImpl.java
+++ b/src/main/java/com/tmg/codingchallenge/presentation/service/CacheExpirationServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +15,6 @@ public class CacheExpirationServiceImpl implements CacheExpirationService {
 
     @Override
     public void clearExpiredCacheEntries() {
-        repository.deleteByExpirationTime(LocalDateTime.now());
+        repository.deleteByExpirationTime(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
     }
 }

--- a/src/test/java/com/tmg/codingchallenge/unittest/cachechallenge/repository/CacheRepositoryTest.java
+++ b/src/test/java/com/tmg/codingchallenge/unittest/cachechallenge/repository/CacheRepositoryTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -29,9 +28,6 @@ class CacheRepositoryTest {
     void clearAllStoredEntries() {
         Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
         cacheEntryMap.clear();
-
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        cacheExpirationEntryMap.clear();
     }
 
     @Test
@@ -41,14 +37,11 @@ class CacheRepositoryTest {
         String cacheEntryValue = "Brandon";
         CacheEntry cacheEntry = new CacheEntry(cacheEntryKey, cacheEntryValue, null);
         Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
 
         // Act
         repository.save(cacheEntry);
 
         // Assert
-        assertTrue(cacheExpirationEntryMap.isEmpty());
-
         assertEquals(1, cacheEntryMap.size());
 
         CacheEntry nameCacheEntry = cacheEntryMap.get(cacheEntryKey);
@@ -138,7 +131,6 @@ class CacheRepositoryTest {
         long cacheEntryTTL = 30L;
         CacheEntry cacheEntry = new CacheEntry(cacheEntryKey, cacheEntryValue, cacheEntryTTL);
         Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
 
         // Act
         repository.save(cacheEntry);
@@ -148,13 +140,6 @@ class CacheRepositoryTest {
 
         CacheEntry nameCacheEntry = cacheEntryMap.get(cacheEntryKey);
         assertEquals(cacheEntry, nameCacheEntry);
-
-        assertEquals(1, cacheExpirationEntryMap.size());
-
-        Map<String, CacheEntry> expirationCacheEntry = cacheExpirationEntryMap.get(nameCacheEntry.getExpiresAt());
-        assertEquals(1, expirationCacheEntry.size());
-
-        assertEquals(cacheEntry, expirationCacheEntry.get(cacheEntryKey));
     }
 
     @Test
@@ -172,9 +157,6 @@ class CacheRepositoryTest {
 
         // Assert
         assertTrue(cacheEntryMap.isEmpty());
-
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -188,17 +170,11 @@ class CacheRepositoryTest {
         Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
         cacheEntryMap.put(cacheEntryKey, cacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> expirationEntryMap = new HashMap<>();
-        expirationEntryMap.put(cacheEntryKey, cacheEntry);
-        cacheExpirationEntryMap.put(cacheEntry.getExpiresAt(), expirationEntryMap);
-
         // Act
         repository.deleteByKey(cacheEntryKey);
 
         // Assert
         assertTrue(cacheEntryMap.isEmpty());
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -222,9 +198,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
-
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -237,11 +210,6 @@ class CacheRepositoryTest {
         CacheEntry firstCacheEntry = new CacheEntry(firstCacheEntryKey, firstCacheEntryValue, 30L);
         cacheEntryMap.put(firstCacheEntryKey, firstCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> expirationEntryMap = new HashMap<>();
-        expirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), expirationEntryMap);
-
         String secondCacheEntryKey = "age";
         String secondCacheEntryValue = "23";
         CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, null);
@@ -253,8 +221,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
-
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -267,11 +233,6 @@ class CacheRepositoryTest {
         CacheEntry firstCacheEntry = new CacheEntry(firstCacheEntryKey, firstCacheEntryValue, 30L);
         cacheEntryMap.put(firstCacheEntryKey, firstCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> expirationEntryMap = new HashMap<>();
-        expirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), expirationEntryMap);
-
         String secondCacheEntryKey = "age";
         String secondCacheEntryValue = "23";
         CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, null);
@@ -283,11 +244,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(firstCacheEntry, cacheEntryMap.get(firstCacheEntryKey));
-
-        assertEquals(1, cacheExpirationEntryMap.size());
-
-        Map<String, CacheEntry> savedCacheExpirationEntries = cacheExpirationEntryMap.get(firstCacheEntry.getExpiresAt());
-        assertEquals(firstCacheEntry, savedCacheExpirationEntries.get(firstCacheEntryKey));
     }
 
     @Test
@@ -300,11 +256,6 @@ class CacheRepositoryTest {
         CacheEntry firstCacheEntry = new CacheEntry(firstCacheEntryKey, firstCacheEntryValue, 30L);
         cacheEntryMap.put(firstCacheEntryKey, firstCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> expirationEntryMap = new HashMap<>();
-        expirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), expirationEntryMap);
-
         String secondCacheEntryKey = "age";
         String secondCacheEntryValue = "23";
         CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, 20L);
@@ -316,11 +267,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(firstCacheEntry, cacheEntryMap.get(firstCacheEntryKey));
-
-        assertEquals(1, cacheExpirationEntryMap.size());
-
-        Map<String, CacheEntry> savedCacheExpirationEntries = cacheExpirationEntryMap.get(firstCacheEntry.getExpiresAt());
-        assertEquals(firstCacheEntry, savedCacheExpirationEntries.get(firstCacheEntryKey));
     }
 
     @Test
@@ -339,9 +285,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(cacheEntry, cacheEntryMap.get(cacheEntryKey));
-
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -355,24 +298,12 @@ class CacheRepositoryTest {
         Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
         cacheEntryMap.put(cacheEntryKey, cacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryByMoment = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> expirationEntryMap = new HashMap<>();
-        expirationEntryMap.put(cacheEntryKey, cacheEntry);
-        cacheExpirationEntryByMoment.put(cacheEntry.getExpiresAt(), expirationEntryMap);
-
         // Act
         repository.deleteByExpirationTime(LocalDateTime.now());
 
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(cacheEntry, cacheEntryMap.get(cacheEntryKey));
-
-        assertEquals(1, cacheExpirationEntryByMoment.size());
-
-        Map<String, CacheEntry> cacheExpirationEntriesByKey = cacheExpirationEntryByMoment.get(cacheEntry.getExpiresAt());
-        assertEquals(1, cacheExpirationEntriesByKey.size());
-
-        assertEquals(cacheEntry, cacheExpirationEntriesByKey.get(cacheEntryKey));
     }
 
     @Test
@@ -397,9 +328,6 @@ class CacheRepositoryTest {
         assertEquals(2, cacheEntryMap.size());
         assertEquals(firstCacheEntry, cacheEntryMap.get(firstCacheEntryKey));
         assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
-
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     @Test
@@ -417,15 +345,6 @@ class CacheRepositoryTest {
         CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, 300L);
         cacheEntryMap.put(secondCacheEntryKey, secondCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> firstExpirationEntryMap = new HashMap<>();
-        firstExpirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), firstExpirationEntryMap);
-
-        HashMap<String, CacheEntry> secondExpirationEntryMap = new HashMap<>();
-        secondExpirationEntryMap.put(secondCacheEntryKey, secondCacheEntry);
-        cacheExpirationEntryMap.put(secondCacheEntry.getExpiresAt(), secondExpirationEntryMap);
-
         // Act
         repository.deleteByExpirationTime(LocalDateTime.now());
 
@@ -433,16 +352,6 @@ class CacheRepositoryTest {
         assertEquals(2, cacheEntryMap.size());
         assertEquals(firstCacheEntry, cacheEntryMap.get(firstCacheEntryKey));
         assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
-
-        assertEquals(2, cacheExpirationEntryMap.size());
-
-        Map<String, CacheEntry> firstExpirationTimeEntries = cacheExpirationEntryMap.get(firstCacheEntry.getExpiresAt());
-        assertEquals(1, firstExpirationTimeEntries.size());
-        assertEquals(firstCacheEntry, firstExpirationTimeEntries.get(firstCacheEntryKey));
-
-        Map<String, CacheEntry> secondExpirationTimeEntries = cacheExpirationEntryMap.get(secondCacheEntry.getExpiresAt());
-        assertEquals(1, secondExpirationTimeEntries.size());
-        assertEquals(secondCacheEntry, secondExpirationTimeEntries.get(secondCacheEntryKey));
     }
 
     @Test
@@ -466,14 +375,34 @@ class CacheRepositoryTest {
         CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, 300L);
         cacheEntryMap.put(secondCacheEntryKey, secondCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> firstExpirationEntryMap = new HashMap<>();
-        firstExpirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), firstExpirationEntryMap);
+        // Act
+        repository.deleteByExpirationTime(LocalDateTime.now());
 
-        HashMap<String, CacheEntry> secondExpirationEntryMap = new HashMap<>();
-        secondExpirationEntryMap.put(secondCacheEntryKey, secondCacheEntry);
-        cacheExpirationEntryMap.put(secondCacheEntry.getExpiresAt(), secondExpirationEntryMap);
+        // Assert
+        assertEquals(1, cacheEntryMap.size());
+        assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
+    }
+
+    @Test
+    void deleteByExpirationTimeWithMultipleKeysAndTTLExpiredInOneButExpiringAnotherTime_withSuccess() {
+        // Arrange
+        Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
+
+        String firstCacheEntryKey = "name";
+        String firstCacheEntryValue = "Jonathan";
+        CacheEntry firstCacheEntry;
+        LocalDateTime localDateTimeForExpiredEntry = getLocalDateTimeForExpiredEntry();
+        try (MockedStatic<LocalDateTime> mock = mockStatic(LocalDateTime.class)) {
+            mock.when(LocalDateTime::now).thenReturn(localDateTimeForExpiredEntry);
+
+            firstCacheEntry = new CacheEntry(firstCacheEntryKey, firstCacheEntryValue, 50L);
+        }
+        cacheEntryMap.put(firstCacheEntryKey, firstCacheEntry);
+
+        String secondCacheEntryKey = "age";
+        String secondCacheEntryValue = "23";
+        CacheEntry secondCacheEntry = new CacheEntry(secondCacheEntryKey, secondCacheEntryValue, 300L);
+        cacheEntryMap.put(secondCacheEntryKey, secondCacheEntry);
 
         // Act
         repository.deleteByExpirationTime(LocalDateTime.now());
@@ -481,12 +410,6 @@ class CacheRepositoryTest {
         // Assert
         assertEquals(1, cacheEntryMap.size());
         assertEquals(secondCacheEntry, cacheEntryMap.get(secondCacheEntryKey));
-
-        assertEquals(1, cacheExpirationEntryMap.size());
-
-        Map<String, CacheEntry> secondExpirationTimeEntries = cacheExpirationEntryMap.get(secondCacheEntry.getExpiresAt());
-        assertEquals(1, secondExpirationTimeEntries.size());
-        assertEquals(secondCacheEntry, secondExpirationTimeEntries.get(secondCacheEntryKey));
     }
 
     @Test
@@ -512,22 +435,11 @@ class CacheRepositoryTest {
         cacheEntryMap.put(firstCacheEntryKey, firstCacheEntry);
         cacheEntryMap.put(secondCacheEntryKey, secondCacheEntry);
 
-        Map<LocalDateTime, Map<String, CacheEntry>> cacheExpirationEntryMap = getCacheExpirationEntryMap();
-        HashMap<String, CacheEntry> firstExpirationEntryMap = new HashMap<>();
-        firstExpirationEntryMap.put(firstCacheEntryKey, firstCacheEntry);
-        cacheExpirationEntryMap.put(firstCacheEntry.getExpiresAt(), firstExpirationEntryMap);
-
-        HashMap<String, CacheEntry> secondExpirationEntryMap = new HashMap<>();
-        secondExpirationEntryMap.put(secondCacheEntryKey, secondCacheEntry);
-        cacheExpirationEntryMap.put(secondCacheEntry.getExpiresAt(), secondExpirationEntryMap);
-
         // Act
         repository.deleteByExpirationTime(LocalDateTime.now());
 
         // Assert
         assertTrue(cacheEntryMap.isEmpty());
-
-        assertTrue(cacheExpirationEntryMap.isEmpty());
     }
 
     private LocalDateTime getLocalDateTimeForExpiredEntry() {
@@ -544,13 +456,4 @@ class CacheRepositoryTest {
         }
     }
 
-    private Map<LocalDateTime, Map<String, CacheEntry>> getCacheExpirationEntryMap() {
-        try {
-            Field privateField = CacheRepository.class.getDeclaredField("expirationMap");
-            privateField.setAccessible(true);
-            return (Map<LocalDateTime, Map<String, CacheEntry>>) privateField.get(repository);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/src/test/java/com/tmg/codingchallenge/unittest/cachechallenge/repository/CacheRepositoryTest.java
+++ b/src/test/java/com/tmg/codingchallenge/unittest/cachechallenge/repository/CacheRepositoryTest.java
@@ -107,6 +107,30 @@ class CacheRepositoryTest {
 
 
     @Test
+    void getOptionalValueByKeyWithTTLExpired_withNoEmptyReturn() {
+        // Arrange
+        String cacheEntryValue = "Garry";
+        String cacheEntryKey = "name";
+        LocalDateTime localDateTimeForExpiredEntry = getLocalDateTimeForExpiredEntry();
+        CacheEntry cacheEntry;
+        try (MockedStatic<LocalDateTime> mock = mockStatic(LocalDateTime.class)) {
+            mock.when(LocalDateTime::now).thenReturn(localDateTimeForExpiredEntry);
+
+            cacheEntry = new CacheEntry(cacheEntryKey, cacheEntryValue, 150L);
+        }
+
+        Map<String, CacheEntry> cacheEntryMap = getCacheEntryMap();
+        cacheEntryMap.put(cacheEntryKey, cacheEntry);
+
+        // Act
+        Optional<String> response = repository.getOptionalValueByKey(cacheEntryKey);
+
+        // Assert
+        assertTrue(response.isEmpty());
+    }
+
+
+    @Test
     void saveNameWithTTL_withSuccess() {
         // Arrange
         String cacheEntryKey = "name";


### PR DESCRIPTION
Instead of running an expiration process every second, I decided to change the expiration process to be a mix of passive and active expiration instead of just the active one because of the code complexity it brought up.

Now the expiration job will run each 30 minutes like a purging process that runs at O(n) and to keep the TTL feature working as intended, the getting cache method in the repository was changed to work as a passive expiration process as well. Having that in mind, every time an expired cache entry is requested, the getting process will check if it's expired and remove it when it's the case.